### PR TITLE
[#12] 회원 관리에 필요한 공통 exception 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,10 +17,11 @@ plugins {
     id "java"
 }
 
-group = "com.bluebird"
 version = "0.0.1-SNAPSHOT"
 
 allprojects {
+    group = "com.bluebird"
+
     apply plugin: "idea"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+springProblemVersion=0.26.2

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
 rootProject.name = 'pipit'
 include 'pipit-api'
 include 'authentication-api'
-
+include 'support'

--- a/support/build.gradle
+++ b/support/build.gradle
@@ -1,0 +1,61 @@
+plugins {
+    id "org.ec4j.editorconfig" version "0.0.3"
+    id "java-library"
+    id "checkstyle"
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+compileJava.options.encoding = "UTF-8"
+compileTestJava.options.encoding = "UTF-8"
+
+idea {
+    module {
+        outputDir file("build/classes/main")
+        testOutputDir file("build/classes/test")
+    }
+}
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
+dependencies {
+    api("com.google.code.findbugs:jsr305:3.0.2")
+    api("com.google.code.findbugs:annotations:3.0.1")
+
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.zalando:problem-spring-web:${springProblemVersion}")
+
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+
+    testCompileOnly("org.projectlombok:lombok")
+    testAnnotationProcessor("org.projectlombok:lombok")
+}
+
+test {
+    useJUnitPlatform()
+}
+
+editorconfig {
+    excludes = ["build"]
+}
+
+check.dependsOn editorconfigCheck
+
+checkstyle {
+    configFile = file("${project.rootDir}/rule/naver-checkstyle-rules.xml")
+    configProperties = [config_loc: ".."]
+    toolVersion = "8.24"
+    ignoreFailures = false
+    maxErrors = 0
+    maxWarnings = 0
+}

--- a/support/src/main/java/com/bluebird/pipit/support/exception/AttributeSupportException.java
+++ b/support/src/main/java/com/bluebird/pipit/support/exception/AttributeSupportException.java
@@ -1,0 +1,59 @@
+package com.bluebird.pipit.support.exception;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+public class AttributeSupportException extends RuntimeException {
+	public static final String INTERNAL_SERVER_ERROR_MESSAGE = "Internal server error.";
+
+	private final Map<String, Object> attributes = new HashMap<>();
+
+	public AttributeSupportException() {
+		super(INTERNAL_SERVER_ERROR_MESSAGE);
+	}
+
+	public AttributeSupportException(String message) {
+		super(message);
+	}
+
+	public AttributeSupportException(Throwable cause) {
+		super(cause);
+	}
+
+	public AttributeSupportException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public AttributeSupportException with(String key, @Nullable Object value) {
+		this.attributes.put(key, value);
+		return this;
+	}
+
+	public Map<String, Object> getAttributes() {
+		return Collections.unmodifiableMap(this.attributes);
+	}
+
+	public ExceptionCode getCode() {
+		return GeneralExceptionCode.GENERAL_ERROR;
+	}
+
+	@Override
+	public String getMessage() {
+		String message = super.getMessage();
+		if (message == null) {
+			message = "";
+		}
+
+		String attributes;
+		if (this.attributes.isEmpty()) {
+			attributes = "{}";
+		} else {
+			attributes = this.attributes.toString();
+		}
+
+		return message + " : " + attributes;
+	}
+}

--- a/support/src/main/java/com/bluebird/pipit/support/exception/ExceptionCode.java
+++ b/support/src/main/java/com/bluebird/pipit/support/exception/ExceptionCode.java
@@ -1,0 +1,5 @@
+package com.bluebird.pipit.support.exception;
+
+public interface ExceptionCode {
+	String name();
+}

--- a/support/src/main/java/com/bluebird/pipit/support/exception/GeneralExceptionCode.java
+++ b/support/src/main/java/com/bluebird/pipit/support/exception/GeneralExceptionCode.java
@@ -1,0 +1,9 @@
+package com.bluebird.pipit.support.exception;
+
+public enum GeneralExceptionCode implements ExceptionCode {
+	GENERAL_ERROR,
+	INVALID_PARAMETER,
+	EXTERNAL_SERVER_ERROR,
+	SERVICE_INVALID,
+	RULE_VIOLATION
+}

--- a/support/src/main/java/com/bluebird/pipit/support/exception/InvalidRequestParameterException.java
+++ b/support/src/main/java/com/bluebird/pipit/support/exception/InvalidRequestParameterException.java
@@ -1,0 +1,22 @@
+package com.bluebird.pipit.support.exception;
+
+import javax.validation.ConstraintViolationException;
+
+import org.springframework.validation.BindException;
+
+public class InvalidRequestParameterException extends AttributeSupportException {
+	public static final String INVALID_REQUEST_PARAMETER_ERROR_MESSAGE = "Some parameters are invalid.";
+
+	public InvalidRequestParameterException(BindException exception) {
+		super(INVALID_REQUEST_PARAMETER_ERROR_MESSAGE, exception);
+	}
+
+	public InvalidRequestParameterException(ConstraintViolationException exception) {
+		super(INVALID_REQUEST_PARAMETER_ERROR_MESSAGE, exception);
+	}
+
+	@Override
+	public ExceptionCode getCode() {
+		return GeneralExceptionCode.INVALID_PARAMETER;
+	}
+}

--- a/support/src/main/java/com/bluebird/pipit/support/exception/ProblemResponseModel.java
+++ b/support/src/main/java/com/bluebird/pipit/support/exception/ProblemResponseModel.java
@@ -1,0 +1,19 @@
+package com.bluebird.pipit.support.exception;
+
+import lombok.Value;
+
+// TODO : Swagger 연동
+@Value
+public class ProblemResponseModel {
+	// 에러 제목
+	String title;
+
+	// 에러 상태 코드
+	int status;
+
+	// 에러 메시지
+	String detail;
+
+	// 에러 구분 코드
+	ExceptionCode code;
+}

--- a/support/src/main/java/com/bluebird/pipit/support/exception/RuleViolationAttributeSupportException.java
+++ b/support/src/main/java/com/bluebird/pipit/support/exception/RuleViolationAttributeSupportException.java
@@ -1,0 +1,15 @@
+package com.bluebird.pipit.support.exception;
+
+public class RuleViolationAttributeSupportException extends AttributeSupportException {
+	private final ExceptionCode code;
+
+	public RuleViolationAttributeSupportException(String message) {
+		super(message);
+		this.code = GeneralExceptionCode.RULE_VIOLATION;
+	}
+
+	@Override
+	public ExceptionCode getCode() {
+		return this.code;
+	}
+}

--- a/support/src/main/java/com/bluebird/pipit/support/exception/ServiceInvalidStatusException.java
+++ b/support/src/main/java/com/bluebird/pipit/support/exception/ServiceInvalidStatusException.java
@@ -1,0 +1,19 @@
+package com.bluebird.pipit.support.exception;
+
+public class ServiceInvalidStatusException extends AttributeSupportException {
+	private final ExceptionCode code;
+
+	public ServiceInvalidStatusException(String message, ExceptionCode code) {
+		super(message);
+		this.code = code;
+	}
+
+	public ServiceInvalidStatusException(String message) {
+		this(message, GeneralExceptionCode.SERVICE_INVALID);
+	}
+
+	@Override
+	public ExceptionCode getCode() {
+		return this.code;
+	}
+}


### PR DESCRIPTION
### TASK 진행 상황
- [x] support module
- [x] Exception Type 정의
- [x] Exception interface
- [ ] Exception Handler

Pipit Server Controller 및 비즈니스 로직에서 공통 관리되어야 하는 exception 위주로 
공통 모듈 생성 및 정의해주었습니다.
아직 구체적인 api 가 나오지 않았기 때문에 기본적으로 사용하는 exception 위주로 작성하였습니다.

각 모듈(authentication, pipit) 별로 관리가 필요한 Exception Code 는 
**해당 모듈 아래서** `ExceptionCode` 인터페이스를 확장하여 정의해주시면 됩니다.

### Reviewers
- @seohyun0120 
- @siyeons 
- @hakyung9712 
- @ArimYeon 