### PR TITLE
[#22] swagger 설정

### DIFF
--- a/authentication-api/build.gradle
+++ b/authentication-api/build.gradle
@@ -26,10 +26,12 @@ configurations {
 
 ext {
     JSOUP_VERSION = "1.8.3"
+    SWAGGER_VERSION = "3.0.0"
 }
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("io.springfox:springfox-boot-starter:${SWAGGER_VERSION}")
     implementation("org.jsoup:jsoup:${JSOUP_VERSION}")
 
     compileOnly("org.projectlombok:lombok")

--- a/authentication-api/src/main/java/com/bluebird/pipit/config/SwaggerConfig.java
+++ b/authentication-api/src/main/java/com/bluebird/pipit/config/SwaggerConfig.java
@@ -1,0 +1,22 @@
+package com.bluebird.pipit.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+
+@Configuration
+public class SwaggerConfig {
+	@Bean
+	Docket api() {
+		return new Docket(DocumentationType.SWAGGER_2)
+			.select()
+			.apis(RequestHandlerSelectors.any())
+			.paths(PathSelectors.any())
+			.build()
+			.useDefaultResponseMessages(false);
+	}
+}

--- a/support/build.gradle
+++ b/support/build.gradle
@@ -25,12 +25,19 @@ configurations {
     }
 }
 
+ext {
+    SPRING_PROBLEM_VERSION = "0.26.2"
+    SWAGGER_VERSION = "3.0.0"
+}
+
 dependencies {
     api("com.google.code.findbugs:jsr305:3.0.2")
     api("com.google.code.findbugs:annotations:3.0.1")
 
     implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("org.zalando:problem-spring-web:${springProblemVersion}")
+    implementation("org.zalando:problem-spring-web:${SPRING_PROBLEM_VERSION}")
+
+    api("io.springfox:springfox-swagger2:${SWAGGER_VERSION}")
 
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")


### PR DESCRIPTION
swagger 3.0.0 이 릴리즈되면서 접근 주소가 변경되었습니다.
로컬에서 배포할 경우 다음 url 로 접근 가능합니다.
- http://localhost:8080/swagger-ui/index.html#/

swagger 는 앱 네이티브 팀 외에도 모든 인원과 서버 엔드포인트 스펙을 공유하기 위해 설정하였습니다.